### PR TITLE
Исправлены возвращаемые типы для методов GetChildByKey и ObtainChildByKey

### DIFF
--- a/lib/xmlelem/index.d.ts
+++ b/lib/xmlelem/index.d.ts
@@ -620,7 +620,7 @@ interface XmElem<T, ForeignElem = never> {
    * @param {string} name - Имя элемента, являющегося ключом. Необязательный аргумент.
    * Если имя ключа не указано, используется первичный ключ.
    */
-  GetChildByKey<K>(value: K, name?: string): XmlElem<unknown>;
+  GetChildByKey<K>(value: K, name?: string): XmlElem<T>;
 
   /**
    * Находит дочерний элемент с заданным значением и возвращает его порядковый индекс.
@@ -773,7 +773,7 @@ interface XmElem<T, ForeignElem = never> {
    * @param {K} value - Значение ключа.
    * @param {string} name - Имя элемента, являющегося ключом. Если имя ключа не указано, используется первичный ключ.
    */
-  ObtainChildByKey<K>(value: K, name?: string): XmlElem<unknown>;
+  ObtainChildByKey<K>(value: K, name?: string): XmlElem<T>;
 
   /**
    * Метод пытается найти среди дочерних элементов элемент с заданным значением

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbrik/webtutor-types",
-  "version": "9.7.3",
+  "version": "9.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbrik/webtutor-types",
-      "version": "9.7.3",
+      "version": "9.7.4",
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^20.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrik/webtutor-types",
-  "version": "9.7.3",
+  "version": "9.7.4",
   "directories": {
     "lib": "lib"
   },

--- a/tests/core.types.ts
+++ b/tests/core.types.ts
@@ -202,15 +202,3 @@ propertyValue2;
 DecodeCharset("teststring", "cp-866");
 EncodeCharset("teststring1", "windows-1251");
 EncodeCharset("teststring2", "windows-1252");
-
-const doc = tools.open_doc<CollaboratorDocument>(1);
-
-if (doc != undefined) {
-  doc.TopElem.firstname.Value = null;
-}
-
-if (doc !== undefined) {
-  doc.TopElem.custom_elems.ObtainChildByKey("custom_elem_field_name").value.Value;
-  doc.TopElem.custom_elems.GetChildByKey("custom_elem_field_name").value.Value;
-}
-

--- a/tests/core.types.ts
+++ b/tests/core.types.ts
@@ -208,3 +208,9 @@ const doc = tools.open_doc<CollaboratorDocument>(1);
 if (doc != undefined) {
   doc.TopElem.firstname.Value = null;
 }
+
+if (doc !== undefined) {
+  doc.TopElem.custom_elems.ObtainChildByKey("custom_elem_field_name").value.Value;
+  doc.TopElem.custom_elems.GetChildByKey("custom_elem_field_name").value.Value;
+}
+

--- a/tests/xmlelem.ts
+++ b/tests/xmlelem.ts
@@ -7,3 +7,15 @@ const foundElement = clonedElement.GetChildIndexByValue(true);
 if (foundElement !== -1) {
   foundElement.Name;
 }
+
+const doc = tools.open_doc<CollaboratorDocument>(1);
+
+if (doc != undefined) {
+  doc.TopElem.firstname.Value = null;
+}
+
+if (doc !== undefined) {
+  doc.TopElem.custom_elems.ObtainChildByKey("custom_elem_field_name").value.Value;
+  doc.TopElem.custom_elems.GetChildByKey("custom_elem_field_name").value.Value;
+  doc.TopElem.firstname.ObtainChildByKey("custom_elem_field_name");
+}


### PR DESCRIPTION
## Изменения

* [x] Теперь методы **GetChildByKey** и **ObtainChildByKey** возвращают `XmlElem<T>` вместо `XmlElem<unknown>`

Resolves #86 